### PR TITLE
fix: resolve authentication 405 error and improve logging

### DIFF
--- a/custom_components/fermax_duoxme/const.py
+++ b/custom_components/fermax_duoxme/const.py
@@ -23,7 +23,7 @@ MIN_POLLING_INTERVAL: Final = 15
 MAX_POLLING_INTERVAL: Final = 300
 
 # Token lifetimes (from API documentation)
-ACCESS_TOKEN_LIFETIME_DAYS: Final = 4
+ACCESS_TOKEN_DEFAULT_LIFETIME: Final = 345599 # ~4 days
 REFRESH_TOKEN_LIFETIME_YEARS: Final = 5
 
 # Platforms


### PR DESCRIPTION
Resolves authentication 405 Method Not Allowed error by using correct OAuth URL. Also enhances logging for authentication failures and uses a constant for token expiration.